### PR TITLE
add history API for scrolling through previous commands

### DIFF
--- a/src/js/bin/ps.js
+++ b/src/js/bin/ps.js
@@ -1,0 +1,16 @@
+var Executable = require('../lib/files/executable');
+
+module.exports = new Executable({
+  name: 'ps',
+  main: function () {
+    var output = '';
+
+    output += 'PID      USER     TIME   COMMAND\r\n';
+    output += '  1   website     0:00   sh\r\n';
+    output += '  2   website     0:00   ps\r\n';
+
+    this.stdout.write(output);
+    this.exit(0);
+  }
+});
+

--- a/src/js/bin/sh/history.js
+++ b/src/js/bin/sh/history.js
@@ -1,0 +1,97 @@
+var File = require('../../lib/files/file');
+var fs = require('../../lib/fs');
+
+module.exports = {};
+
+module.exports.Previous = function (callback) {
+    callback = callback || function () {};
+
+    if (history.cursor > 0) {
+        history.cursor--;
+        return callback(null, history.Get(history.cursor));
+    }
+
+    if (history.cursor >= history.Length()) {
+        return callback(null, history.scratchpad);
+    }
+
+    return callback(null, history.Get(history.cursor));
+}
+
+module.exports.Next = function (callback) {
+    callback = callback || function () {};
+
+    if (history.cursor < history.Length()) {
+        history.cursor++;
+    }
+
+    if (typeof history.Get(history.cursor) !== 'undefined') {
+        return callback(null, history.Get(history.cursor));
+    }
+
+    return callback(null, history.scratchpad);
+}
+
+module.exports.Append = function (contents) {
+    if (typeof contents !== 'string') {
+        contents = '';
+    }
+
+    module.exports.SetScratchpad('');
+
+    if (contents !== '') {
+        history.Push(contents);
+    }
+}
+
+module.exports.SetScratchpad = function (contents) {
+    history.scratchpad = contents;
+}
+
+var history = {
+    items: [],
+    localStorageKey: 'bash_history',
+    scratchpad: '',
+    cursor: 0,
+};
+
+var persist = function () {
+    localStorage.setItem(history.localStorageKey, JSON.stringify(history.items));
+    fs.write('/home/website/.bash_history', new File({contents: history.items.join('\n')}));
+}
+
+history.Load = function () {
+    try {
+        this.items = JSON.parse(localStorage.getItem(this.localStorageKey));
+    } catch (e) {
+        this.items = [];
+    }
+
+    if (this.items === null) {
+        this.items = [];
+    }
+
+    persist();
+
+    this.cursor = this.Length();
+};
+
+history.Push = function (item) {
+    item = item.trim();
+    var pushResult = this.items.push(item);
+    this.cursor = this.Length();
+    persist();
+
+    return pushResult;
+};
+
+history.Get = function (index) {
+    return this.items[index];
+};
+
+history.Length = function () {
+    return this.items.length;
+};
+
+
+history.Load();

--- a/src/js/bin/sh/readline.js
+++ b/src/js/bin/sh/readline.js
@@ -39,8 +39,7 @@ module.exports = function () {
   };
 
   var handleInput = function (input) {
-    // debugger;
-    if (input === '') {
+    if (input.trim() === '') {
       return prompt.prompt(handleInput);
     }
 

--- a/src/js/bin/whoami.js
+++ b/src/js/bin/whoami.js
@@ -1,0 +1,11 @@
+var Executable = require('../lib/files/executable');
+
+module.exports = new Executable({
+  name: 'whoami',
+  main: function () {
+    var output = 'website\r\n';
+    this.stdout.write(output);
+    this.exit(0);
+  }
+});
+

--- a/src/js/lib/init.js
+++ b/src/js/lib/init.js
@@ -23,11 +23,13 @@ module.exports = function () {
   fs.write('/bin/cat', require('../bin/cat'));
   fs.write('/usr/bin/cd', require('../bin/cd'));
   fs.write('/bin/ls', require('../bin/ls'));
+  fs.write('/bin/ps', require('../bin/ps'));
   fs.write('/bin/pwd', require('../bin/pwd'));
   fs.write('/sbin/reboot', require('../sbin/reboot'));
   fs.write('/bin/sleep', require('../bin/sleep'));
   fs.write('/bin/mkdir', require('../bin/mkdir'));
   fs.write('/bin/sh', require('../bin/sh'));
+  fs.write('/usr/bin/whoami', require('../bin/whoami'));
   fs.write('/usr/local/bin/view', require('../bin/view'));
   fs.write('/usr/local/bin/open', require('../bin/open'));
 


### PR DESCRIPTION
adds a history API to the shell that keeps an array of commands the user has previously typed.

* keeps the most recent command being typed in a temporary "scratchpad"
* persists command history to localStorage
* writes command history to `/home/website/.bash_history` just for fun

Also added dummy `ps` and `whoami` executables to have more commands to play around with.